### PR TITLE
docs: documenter les tests en environnement réel

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,14 @@ npm run live:api
 Par défaut le serveur écoute sur `http://0.0.0.0:3031`. Lancez ensuite l'interface :
 
 ```bash
+# macOS / Linux
 VITE_SOCIAL_API_URL=http://localhost:3031 npm run dev
+
+# Windows (PowerShell)
+$env:VITE_SOCIAL_API_URL="http://localhost:3031"; npm run dev
+
+# Windows (Invite de commandes)
+set "VITE_SOCIAL_API_URL=http://localhost:3031" && npm run dev
 ```
 
 | Réseau     | Variables requises | Remarques |
@@ -51,14 +58,28 @@ npm run mock:api
 Il écoute sur `http://0.0.0.0:3030`. Démarrez l'interface dans un autre terminal :
 
 ```bash
+# macOS / Linux
 VITE_SOCIAL_API_URL=http://localhost:3030 npm run dev
+
+# Windows (PowerShell)
+$env:VITE_SOCIAL_API_URL="http://localhost:3030"; npm run dev
+
+# Windows (Invite de commandes)
+set "VITE_SOCIAL_API_URL=http://localhost:3030" && npm run dev
 ```
 
 ### 3. Avec votre propre backend
 Exposez des endpoints compatibles avec ceux utilisés dans `src/api` puis définissez l'URL :
 
 ```bash
+# macOS / Linux
 VITE_SOCIAL_API_URL=https://mon-backend.exemple.com npm run dev
+
+# Windows (PowerShell)
+$env:VITE_SOCIAL_API_URL="https://mon-backend.exemple.com"; npm run dev
+
+# Windows (Invite de commandes)
+set "VITE_SOCIAL_API_URL=https://mon-backend.exemple.com" && npm run dev
 ```
 
 ## Scripts utiles
@@ -86,7 +107,7 @@ Pour valider l'application avec des données de production, suivez les étapes c
 
 1. **Préparer les accès** – Collectez les identifiants listés dans le tableau ci-dessus et exportez-les dans votre shell (ou votre `.env.local`). Sans ces valeurs, les plateformes refuseront la plupart des appels live.
 2. **Lancer le proxy social** – Exécutez `npm run live:api` pour démarrer `scripts/social-live-api.mjs`. Vérifiez dans la console que chaque connecteur démarre sans erreur 4xx/5xx.
-3. **Démarrer l'interface** – Dans un second terminal, lancez `VITE_SOCIAL_API_URL=http://localhost:3031 npm run dev` afin de pointer l'UI vers le proxy live. Naviguez vers `http://localhost:5173` (par défaut) et recherchez un influenceur réel pour confirmer la récupération des métriques.
+3. **Démarrer l'interface** – Dans un second terminal, définissez `VITE_SOCIAL_API_URL` (voir exemples ci-dessus) puis lancez `npm run dev` afin de pointer l'UI vers le proxy live. Naviguez vers `http://localhost:5173` (par défaut) et recherchez un influenceur réel pour confirmer la récupération des métriques.
 4. **Analyser les journaux** – Surveillez le terminal du proxy : vous y verrez les requêtes effectuées vers les réseaux sociaux ainsi que les éventuelles erreurs de permission ou de quota. Corrigez les identifiants si nécessaire.
 5. **Désactiver le fallback mock** – Pour vous assurer que seules les données réelles sont utilisées, définissez `VITE_ALLOW_MOCK_FALLBACK=false` avant de relancer `npm run dev`.
 

--- a/README.md
+++ b/README.md
@@ -114,8 +114,30 @@ Pour valider l'application avec des données de production, suivez les étapes c
 Ces actions reproduisent les conditions de production tout en restant sur votre machine de développement. Une fois validées, vous pouvez déployer le proxy et l'interface sur votre infrastructure cible.
 
 ## Déploiement
+
+### Publier sur Vercel pas à pas
+
+1. **Préparer le projet**  
+   Vérifiez que le dépôt Git contient bien le code à déployer et que le fichier `package.json` définit les scripts standards (`npm run build`, `npm run dev`, etc.). Commitez vos derniers changements puis poussez-les vers le dépôt distant (GitHub, GitLab, Bitbucket ou Vercel Git).
+2. **Créer/relier le projet Vercel**  
+   - _Depuis l'interface web_ : rendez-vous sur [vercel.com](https://vercel.com), cliquez sur **New Project** puis importez votre dépôt.  
+   - _Via le CLI_ : installez l'outil avec `npm i -g vercel`, exécutez `vercel login` puis `vercel` à la racine du projet pour lier le répertoire courant à un projet Vercel.
+3. **Configurer la construction**  
+   Vercel détecte automatiquement Vite. Vérifiez néanmoins dans **Settings → Build & Development → Build Command** que la commande est `npm run build` et que le dossier de sortie est `dist`. Si vous utilisez le CLI, répondez `npm run build` à la question *"What is your Build Command?"* et `dist` pour *"Output Directory"* lors du premier déploiement.
+4. **Définir les variables d'environnement**  
+   Dans **Settings → Environment Variables**, ajoutez au minimum `VITE_SOCIAL_API_URL` (URL de votre backend/proxy social). Ajoutez également `VITE_ALLOW_MOCK_FALLBACK=false` pour empêcher le repli sur les données mockées. Renseignez les valeurs dans les environnements **Production**, **Preview** et **Development** selon vos besoins.
+5. **Lancer le déploiement**  
+   - _Via Git_ : chaque `git push` sur la branche principale déclenche un déploiement de production ; les autres branches génèrent des aperçus (Preview).  
+   - _Via CLI_ : exécutez `vercel --prod` pour déployer la branche courante en production, ou simplement `vercel` pour créer un aperçu.
+6. **Vérifier le résultat**  
+   Une fois le build terminé, ouvrez l'URL fournie par Vercel. Testez les flux critiques (recherche d'influenceurs, affichage des métriques) et contrôlez la console navigateur pour détecter d'éventuelles erreurs CORS ou d'URL.
+
+> 💡 Le proxy social (`npm run live:api`) n'est pas déployé automatiquement sur Vercel. Hébergez-le sur une plateforme compatible Node (Vercel functions, Fly.io, Railway, etc.) ou sur votre infrastructure. Pointez ensuite `VITE_SOCIAL_API_URL` vers cette instance publique.
+
+### Autres plateformes
+
 1. Construire le bundle : `npm run build`
-2. Déployer le dossier `dist` sur la plateforme de votre choix (Netlify, Vercel, etc.)
+2. Déployer le dossier `dist` sur la plateforme de votre choix (Netlify, Cloudflare Pages, etc.)
 3. Configurer la variable d'environnement `VITE_SOCIAL_API_URL` vers votre API publique si vous souhaitez utiliser des données temps réel.
 
 ## Prochaines étapes suggérées

--- a/README.md
+++ b/README.md
@@ -80,6 +80,18 @@ VITE_ALLOW_MOCK_FALLBACK=true
 
 Les données de démonstration sont stockées dans `src/data/mockSocialData.json`.
 
+## Tester en environnement réel
+
+Pour valider l'application avec des données de production, suivez les étapes ci-dessous :
+
+1. **Préparer les accès** – Collectez les identifiants listés dans le tableau ci-dessus et exportez-les dans votre shell (ou votre `.env.local`). Sans ces valeurs, les plateformes refuseront la plupart des appels live.
+2. **Lancer le proxy social** – Exécutez `npm run live:api` pour démarrer `scripts/social-live-api.mjs`. Vérifiez dans la console que chaque connecteur démarre sans erreur 4xx/5xx.
+3. **Démarrer l'interface** – Dans un second terminal, lancez `VITE_SOCIAL_API_URL=http://localhost:3031 npm run dev` afin de pointer l'UI vers le proxy live. Naviguez vers `http://localhost:5173` (par défaut) et recherchez un influenceur réel pour confirmer la récupération des métriques.
+4. **Analyser les journaux** – Surveillez le terminal du proxy : vous y verrez les requêtes effectuées vers les réseaux sociaux ainsi que les éventuelles erreurs de permission ou de quota. Corrigez les identifiants si nécessaire.
+5. **Désactiver le fallback mock** – Pour vous assurer que seules les données réelles sont utilisées, définissez `VITE_ALLOW_MOCK_FALLBACK=false` avant de relancer `npm run dev`.
+
+Ces actions reproduisent les conditions de production tout en restant sur votre machine de développement. Une fois validées, vous pouvez déployer le proxy et l'interface sur votre infrastructure cible.
+
 ## Déploiement
 1. Construire le bundle : `npm run build`
 2. Déployer le dossier `dist` sur la plateforme de votre choix (Netlify, Vercel, etc.)


### PR DESCRIPTION
## Summary
- add a dedicated section to the README explaining how to validate the app with live social APIs
- detail the required credentials, commands to run, and tips for monitoring logs during real-world tests

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e3c07e29588327921a965f31e8ecd3